### PR TITLE
FDN-4581 Remove pr-validator workflow

### DIFF
--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -1,8 +1,0 @@
-name: "PR Title and Description Check"
-on:
-  pull_request:
-    types: [opened, edited, synchronize]
-jobs:
-  validate:
-    uses: flowcommerce/code-steward/.github/workflows/pr-validator.yml@main
-


### PR DESCRIPTION
Public repos cannot call reusable workflows from private repos (code-steward). Removing the pr-validator.yml that was added in error.

<!-- @coderabbitai: ignore -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the PR validation GitHub Actions workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->